### PR TITLE
Don't change column widths

### DIFF
--- a/tablefilter.js
+++ b/tablefilter.js
@@ -62,6 +62,7 @@
         for (let i = 0; i < firstCells.length; i++) {
             let filterCell = document.createElement('td');
             let filterInput = document.createElement('input');
+            filterInput.style.width = (firstCells[i].getBoundingClientRect()['width'] - 10) + 'px';
             filterInput.addEventListener("keyup", function () {
                 filterTable(table, filterRow);
             });


### PR DESCRIPTION
Set the width of each input so that the column stays the same width. Subtract
10 pixels from the bounding box of the cell to allow for margins.
Expirementation showed that 6 pixels is enough.